### PR TITLE
fix: install rest_framework.authtoken

### DIFF
--- a/backend/apiserver/settings.py
+++ b/backend/apiserver/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
     'corsheaders',
     'api.apps.ApiConfig',
 ]


### PR DESCRIPTION
これなしでは `python manage.py createsuperuser` がエラーを出すようです。