### PR TITLE
feat: add requirements for Django REST Framework

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,6 @@
 Django~=2.2.4
+authentication
+serializer
+djangorestframework
+djangorestframework-jwt
+django-cors-headers


### PR DESCRIPTION
Django REST Framework を使うための依存モジュールを requirements.txt に追加します。