### PR TITLE
Fix API specification

### DIFF
--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -801,7 +801,7 @@ paths:
     get:
       tags:
         - goods
-      summary: フォローを一覧する。
+      summary: いいねを一覧する。
       description: サービス上に存在する全てのいいねを一覧する。user を指定するとそのユーザーからのいいねに絞り込む。post を指定するとそのユーザーへのいいねに絞り込む。
       parameters:
         - name: user

--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -41,7 +41,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                type: object
+                properties:
+                  token:
+                    type: string
         "401":
           description: |
             メールアドレスが登録されていないかパスワードが異なる。

--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -85,6 +85,34 @@ paths:
                   error:
                     type: string
                     example: no active user
+  /auth/me:
+    get:
+      tags:
+        - auth
+      security:
+        - bearer: []
+      summary: 現在ログインしているユーザーの情報を得る。
+      responses:
+        "200":
+          description: 成功。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "401":
+          description: |
+            ログインしていない。
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 1001
+                  error:
+                    type: string
+                    example: no active user
   /users:
     post:
       tags:
@@ -159,34 +187,6 @@ paths:
                   error:
                     type: string
                     example: specified user not found
-  /me:
-    get:
-      tags:
-        - users
-      security:
-        - bearer: []
-      summary: 現在ログインしているユーザーの情報を得る。
-      responses:
-        "200":
-          description: 成功。
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        "401":
-          description: |
-            ログインしていない。
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  code:
-                    type: integer
-                    example: 1001
-                  error:
-                    type: string
-                    example: no active user
   /lives:
     get:
       tags:

--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -675,6 +675,8 @@ paths:
     delete:
       tags:
         - follows
+      security:
+        - bearer: []
       summary: フォローを解除する。
       parameters:
         - name: follow_id
@@ -845,6 +847,8 @@ paths:
     delete:
       tags:
         - goods
+      security:
+        - bearer: []
       summary: いいねを解除する。
       parameters:
         - name: good_id


### PR DESCRIPTION
とりあえず必須と思われる変更を入れます。

- /me を /auth/me に移動します。
- フォロー解除、いいね解除の API にも認証を求めます。
- ログイン時、ユーザー情報ではなく認証用のトークンを返します。 (Authorization ヘッダに設定してもらうものです。)