### PR TITLE
refactor: route entire / to implement other APIs

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,7 +3,7 @@ from rest_framework import routers
 from .views import AuthRegister, AuthInfoGetView, AuthInfoUpdateView
 
 urlpatterns = [
-    url(r'^users/$', AuthRegister.as_view()),
-    url(r'^me/$', AuthInfoGetView.as_view()),
-    url(r'^auth_update/$', AuthInfoUpdateView.as_view()),
+    url(r'^auth/users/$', AuthRegister.as_view()),
+    url(r'^auth/me/$', AuthInfoGetView.as_view()),
+    url(r'^auth/auth_update/$', AuthInfoUpdateView.as_view()),
 ]

--- a/backend/apiserver/urls.py
+++ b/backend/apiserver/urls.py
@@ -21,6 +21,5 @@ from rest_framework_jwt.views import obtain_jwt_token
 urlpatterns = [
     path('admin/', admin.site.urls),
     url(r'^login/', obtain_jwt_token),
-    url(r'^auth/', include('api.urls'))
-
+    path('', include('api.urls'))
 ]


### PR DESCRIPTION
他の API を実装できるようにするために、/auth だけでなく / 全体をマップします。