### PR TITLE
fix: use same formatting for DRF errors

### DIFF
--- a/backend/api/errors.py
+++ b/backend/api/errors.py
@@ -1,4 +1,18 @@
 from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+
+# 我々の API の規約に合うようにハンドラを設定する
+def custom_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+    if response is not None:
+        original = response.data
+        response.data = {
+            "code": -1,
+            "error": "unhandled error",
+            "original": original,
+        }
+    return response
 
 
 def error_response(status, code, error):

--- a/backend/apiserver/settings.py
+++ b/backend/apiserver/settings.py
@@ -148,6 +148,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication'
     ),
     'NON_FIELD_ERRORS_KEY': 'detail',
-    'TEST_REQUEST_DEFAULT_FORMAT': 'json'
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+    'EXCEPTION_HANDLER': 'api.errors.custom_exception_handler',
 }
 


### PR DESCRIPTION
エラーのときはどこでも { 'code': ..., 'error': ... } を仮定できるように
する。